### PR TITLE
[API] feat: add new api route to create a feedback

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,12 +6,12 @@ import { errorHandling } from './infrastructure/http/middleware/errorHandling';
 import { schoolRoutes } from './infrastructure/http/routes/schoolRoutes';
 import { dashboardRoutes } from './infrastructure/http/routes/dashboardRoutes';
 import { municipalityRoutes } from './infrastructure/http/routes/municipalityRoutes';
+import { feedbackRoutes } from './infrastructure/http/routes/feedbackRoutes';
 
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './infrastructure/configs/swagger';
 
 const app = express();
-// const BASE_PATH = config.BASE_PATH;
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -20,6 +20,7 @@ const allowedOrigins = [
   'http://localhost:5173',
   'http://localhost:5174',
   'https://development.dbvzz9cfb1jf.amplifyapp.com',
+  'https://main.dbvzz9cfb1jf.amplifyapp.com',
 ];
 
 app.use(
@@ -41,6 +42,8 @@ app.use(schoolRoutes);
 app.use(dashboardRoutes);
 
 app.use(municipalityRoutes);
+
+app.use(feedbackRoutes);
 
 app.get('/', (req: Request, res: Response) => {
   res.status(200).json({

--- a/server/src/application/UseCases/Feedback/CreateFeedbackUseCase/CreateFeedbackUseCase.ts
+++ b/server/src/application/UseCases/Feedback/CreateFeedbackUseCase/CreateFeedbackUseCase.ts
@@ -1,0 +1,63 @@
+import { IFeedback } from '../../../../domain/entities/Feedback';
+import { FeedbackStatus } from '../../../../domain/enums/Feedback/enumFeedbackStatus';
+import { FeedbackType } from '../../../../domain/enums/Feedback/enumFeedbackType';
+import { IFeedbackRepository } from '../../../../domain/repositories/feedbackRepository';
+import { AppError } from '../../../../shared/utils/errors/appError';
+import {
+  ICreateFeedbackInputDTO,
+  ICreateFeedbackOutputDTO,
+} from './DTOs/CreateFeedbackUseCase';
+
+/**
+ * @description Use case for creating feedback.
+ */
+export class CreateFeedbackUseCase {
+  constructor(private feedbackRepository: IFeedbackRepository) {}
+
+  /**
+   * @description Creates feedback.
+   * @param data - Data required to create feedback.
+   * @returns The created feedback.
+   */
+  public async execute(
+    data: ICreateFeedbackInputDTO,
+  ): Promise<ICreateFeedbackOutputDTO> {
+    CreateFeedbackUseCase._validateData(data);
+
+    const feedbackToSave: IFeedback = {
+      message: data.message,
+      type: data.type,
+      page: data.page,
+      status: FeedbackStatus.NEW,
+    };
+
+    const createdFeedback = await this.feedbackRepository.save(feedbackToSave);
+
+    return {
+      id: createdFeedback.id!,
+      message: createdFeedback.message,
+      type: createdFeedback.type,
+      status: createdFeedback.status,
+      createdAt: createdFeedback.createdAt!,
+    };
+  }
+
+  /**
+   *
+   * @param props - Partial feedback data to validate.
+   * @throws Will throw an error if validation fails.
+   */
+  private static _validateData(props: Partial<IFeedback>) {
+    {
+      if (!props.message || props.message.trim().length < 10) {
+        throw new AppError(
+          'The feedback message must be at least 10 characters long.',
+        );
+      }
+
+      if (!props.type || !Object.values(FeedbackType).includes(props.type)) {
+        throw new AppError('The feedback type is invalid.');
+      }
+    }
+  }
+}

--- a/server/src/application/UseCases/Feedback/CreateFeedbackUseCase/DTOs/CreateFeedbackUseCase.ts
+++ b/server/src/application/UseCases/Feedback/CreateFeedbackUseCase/DTOs/CreateFeedbackUseCase.ts
@@ -1,0 +1,22 @@
+import { FeedbackStatus } from '../../../../../domain/enums/Feedback/enumFeedbackStatus';
+import { FeedbackType } from '../../../../../domain/enums/Feedback/enumFeedbackType';
+
+/**
+ * @description DTO for creating feedback.
+ */
+export interface ICreateFeedbackInputDTO {
+  message: string;
+  type: FeedbackType;
+  page?: string;
+}
+
+/**
+ * @description DTO for the output after creating feedback.
+ */
+export interface ICreateFeedbackOutputDTO {
+  id: string;
+  message: string;
+  type: FeedbackType;
+  status: FeedbackStatus;
+  createdAt: Date;
+}

--- a/server/src/domain/entities/Feedback.ts
+++ b/server/src/domain/entities/Feedback.ts
@@ -1,0 +1,15 @@
+import { FeedbackStatus } from '../enums/Feedback/enumFeedbackStatus';
+import { FeedbackType } from '../enums/Feedback/enumFeedbackType';
+
+/**
+ * @description Interface representing a feedback entry.
+ */
+export interface IFeedback {
+  id?: string;
+  message: string;
+  type: FeedbackType;
+  page?: string;
+  status: FeedbackStatus;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/server/src/domain/enums/Feedback/enumFeedbackStatus.ts
+++ b/server/src/domain/enums/Feedback/enumFeedbackStatus.ts
@@ -1,0 +1,12 @@
+/**
+ * @enum FeedbackStatus
+ *
+ * @description Enum representing the status of feedback,
+ * we can add more statuses in the future if needed.
+ */
+export enum FeedbackStatus {
+  NEW = 'new',
+  VIEWED = 'viewed',
+  IN_PROGRESS = 'in-progress',
+  RESOLVED = 'resolved',
+}

--- a/server/src/domain/enums/Feedback/enumFeedbackType.ts
+++ b/server/src/domain/enums/Feedback/enumFeedbackType.ts
@@ -1,0 +1,12 @@
+/**
+ * @enum FeedbackType
+ *
+ * @description Enum representing the type of feedback.
+ * We can expand this enum in the future if needed.
+ */
+export enum FeedbackType {
+  BUG = 'bug',
+  SUGGESTION = 'suggestion',
+  PRAISE = 'praise',
+  OTHER = 'other',
+}

--- a/server/src/domain/repositories/feedbackRepository.ts
+++ b/server/src/domain/repositories/feedbackRepository.ts
@@ -1,0 +1,9 @@
+import { IFeedback } from '../entities/Feedback';
+
+/**
+ * @description Interface for the Feedback repository.
+ */
+export interface IFeedbackRepository {
+  save(feedback: IFeedback): Promise<IFeedback>;
+  // In the future we can add methods like findById, updateStatus, etc.
+}

--- a/server/src/infrastructure/configs/models/mongooseFeedbackModel.ts
+++ b/server/src/infrastructure/configs/models/mongooseFeedbackModel.ts
@@ -1,0 +1,23 @@
+import { model, Schema } from 'mongoose';
+import { IFeedback } from '../../../domain/entities/Feedback';
+import { FeedbackStatus } from '../../../domain/enums/Feedback/enumFeedbackStatus';
+import { FeedbackType } from '../../../domain/enums/Feedback/enumFeedbackType';
+
+/**
+ * @description Mongoose schema and model for Feedback.
+ */
+const feedbackSchema = new Schema<IFeedback>(
+  {
+    message: { type: String, required: true },
+    type: { type: String, enum: Object.values(FeedbackType), required: true },
+    page: { type: String },
+    status: {
+      type: String,
+      enum: Object.values(FeedbackStatus),
+      default: FeedbackStatus.NEW,
+    },
+  },
+  { timestamps: true },
+);
+
+export const FeedbackModel = model<IFeedback>('Feedback', feedbackSchema);

--- a/server/src/infrastructure/database/repository/mongooseFeedbackRepository.ts
+++ b/server/src/infrastructure/database/repository/mongooseFeedbackRepository.ts
@@ -1,0 +1,16 @@
+import { IFeedback } from '../../../domain/entities/Feedback';
+import { IFeedbackRepository } from '../../../domain/repositories/feedbackRepository';
+import { FeedbackModel } from '../../configs/models/mongooseFeedbackModel';
+
+/**
+ * @implements IFeedbackRepository
+ * @description Mongoose implementation of the Feedback repository.
+ *
+ * @method save - Saves a feedback entry to the database.
+ */
+export class MongooseFeedbackRepository implements IFeedbackRepository {
+  async save(feedback: IFeedback): Promise<IFeedback> {
+    const newFeedback = await FeedbackModel.create(feedback);
+    return newFeedback.toObject();
+  }
+}

--- a/server/src/infrastructure/http/controller/FeedbackController/CreateFeedbackController/CreateFeedbackController.ts
+++ b/server/src/infrastructure/http/controller/FeedbackController/CreateFeedbackController/CreateFeedbackController.ts
@@ -1,0 +1,100 @@
+import z from 'zod';
+import { Request, Response } from 'express';
+import { CreateFeedbackUseCase } from '../../../../../application/UseCases/Feedback/CreateFeedbackUseCase/CreateFeedbackUseCase';
+import { FeedbackType } from '../../../../../domain/enums/Feedback/enumFeedbackType';
+
+/**
+ * @description Controller for creating feedback.
+ * @route POST /feedback
+ * @body {string} message - The feedback message.
+ * @body {FeedbackType} type - The type of feedback.
+ * @body {string} [page] - The page where the feedback was given.
+ */
+export class CreateFeedbackController {
+  constructor(private createFeedbackUseCase: CreateFeedbackUseCase) {}
+
+  /**
+   * @swagger
+   * /api/v1/feedback:
+   *   post:
+   *     summary: Register a new user feedback.
+   *     description: Creates a new feedback entry in the system based on the data sent by the user. Used by the floating feedback button on the platform.
+   *     tags:
+   *       - Feedback
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - message
+   *               - type
+   *             properties:
+   *               message:
+   *                 type: string
+   *                 description: The content of the feedback message. Must have at least 10 characters.
+   *                 example: "I found the map visualization of municipalities a bit slow on my phone."
+   *               type:
+   *                 type: string
+   *                 description: The feedback category.
+   *                 enum: [bug, suggestion, praise, other]
+   *                 example: "suggestion"
+   *               page:
+   *                 type: string
+   *                 description: (Optional) The URL of the page from where the feedback was submitted.
+   *                 example: "/schools/25125710"
+   *     responses:
+   *       '201':
+   *         description: Feedback successfully created.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 id:
+   *                   type: string
+   *                   example: "64f7b4b3a1b2c3d4e5f6a7b8"
+   *                 message:
+   *                   type: string
+   *                   example: "I found the map visualization of municipalities a bit slow on my phone."
+   *                 type:
+   *                   type: string
+   *                   example: "suggestion"
+   *                 status:
+   *                   type: string
+   *                   example: "new"
+   *                 page:
+   *                   type: string
+   *                   example: "/schools/25125710"
+   *                 createdAt:
+   *                   type: string
+   *                   format: date-time
+   *                   example: "2025-09-05T12:30:00.000Z"
+   *       '400':
+   *         description: Validation error. The submitted data is invalid.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: "The feedback message must have at least 10 characters."
+   *       '500':
+   *         description: Internal server error.
+   */
+  async handle(req: Request, res: Response): Promise<Response> {
+    const bodySchema = z.object({
+      message: z.string(),
+      type: z.enum(FeedbackType),
+      page: z.string().optional(),
+    });
+
+    const validatedBody = bodySchema.parse(req.body);
+
+    const feedback = await this.createFeedbackUseCase.execute(validatedBody);
+
+    return res.status(201).json(feedback);
+  }
+}

--- a/server/src/infrastructure/http/controller/FeedbackController/index.ts
+++ b/server/src/infrastructure/http/controller/FeedbackController/index.ts
@@ -1,0 +1,11 @@
+import { CreateFeedbackUseCase } from '../../../../application/UseCases/Feedback/CreateFeedbackUseCase/CreateFeedbackUseCase';
+import { MongooseFeedbackRepository } from '../../../database/repository/mongooseFeedbackRepository';
+import { CreateFeedbackController } from './CreateFeedbackController/CreateFeedbackController';
+
+const feedbackRepository = new MongooseFeedbackRepository();
+
+const createFeedbackUseCase = new CreateFeedbackUseCase(feedbackRepository);
+
+export const createFeedbackController = new CreateFeedbackController(
+  createFeedbackUseCase,
+);

--- a/server/src/infrastructure/http/routes/feedbackRoutes.ts
+++ b/server/src/infrastructure/http/routes/feedbackRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+import * as feedbackController from '../controller/FeedbackController/index';
+
+const feedbackRoutes = Router();
+
+feedbackRoutes.post(
+  '/api/v1/feedback',
+  feedbackController.createFeedbackController.handle.bind(
+    feedbackController.createFeedbackController,
+  ),
+);
+
+export { feedbackRoutes };


### PR DESCRIPTION
## O que este PR faz?
Implementa todo o fluxo de criação de feedbacks, inserindo os feedbacks em uma nova collection "Feedbacks" no banco de dados. 

Tentei seguir o padrão utilizado pelo colega samuel e também fazer do meu jeitinho algumas coisas, então não estranhe kk

## Link da Task no Linear:
Fixes OEPB-68

## Screenshots ou GIFs (se aplicável)
<img width="473" height="512" alt="image" src="https://github.com/user-attachments/assets/157ba2e3-0e7d-45a4-8dea-d7b3e77e94e0" />
<img width="1417" height="826" alt="image" src="https://github.com/user-attachments/assets/fe12d180-cd3c-46e2-91bc-9d751bd2e86a" />


## Checklist de Qualidade

- [ ] Meu código segue as boas práticas e a arquitetura que definimos para o projeto.
- [ ] Eu testei minhas alterações localmente e elas funcionam como esperado.

### Checklist de Pré-Submissão

_Antes de abrir esta PR, por favor, confirme que você completou os seguintes passos:_

- [ ] Eu testei minhas alterações localmente.
- [ ] Eu li e preenchi as seções acima.
