### PR TITLE
[Client][Simulator] feat: implements the visual client side in simulator page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,8 @@
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.84.2",
         "@tanstack/react-query-devtools": "^5.84.2",
@@ -1839,6 +1841,65 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,8 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.84.2",
     "@tanstack/react-query-devtools": "^5.84.2",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,8 @@ import { TooltipProvider } from './ui/components/common/tooltip';
 import SchoolDetailsPage from './modules/Schools/SchoolDetails/SchoolDetailsPage';
 import MunicipalityPage from './modules/Municipality/MunicipalityPage';
 import MunicipalityDetailsPage from './modules/Municipality/MunicipalityDetails/MunicipalityDetails';
+import SimulatorDetailsPage from './modules/Simulator/SimulatorDetails/SimulatorDetailsPage';
+import SimulatorPage from './modules/Simulator/SimulatorPage';
 
 function App() {
   return (
@@ -24,6 +26,9 @@ function App() {
                 path="/municipios/:id"
                 element={<MunicipalityDetailsPage />}
               />
+              <Route path="/simulador" element={<SimulatorPage />} />
+              <Route path="/simulador/:id" element={<SimulatorDetailsPage />} />
+              <Route path='/necessidades' />
             </Route>
           </Routes>
         </DashboardProvider>

--- a/client/src/modules/Municipality/MunicipalityDetails/MunicipalityDetails.tsx
+++ b/client/src/modules/Municipality/MunicipalityDetails/MunicipalityDetails.tsx
@@ -13,6 +13,7 @@ import { usePagination } from '@/ui/hooks/usePagination';
 import { useState } from 'react';
 import { CustomPagination } from '@/ui/components/common/CustomPagination';
 import { MunicipalityStatsPanel } from './components/MunicipalityStatsPanel';
+import { School } from '@/domain/entities/School/SchoolProps';
 
 const TABLE_PAGE_SIZE = 10;
 
@@ -89,6 +90,10 @@ const MunicipalityDetailsPage = () => {
     );
   }
 
+  const handleSelectSchool = (school: School) => {
+    navigate(`/escolas/${school.id}`); 
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -123,7 +128,10 @@ const MunicipalityDetailsPage = () => {
 
         {schoolsForTable.length > 0 ? (
           <>
-            <SchoolsTable data={schoolsForTable} />
+            <SchoolsTable
+              data={schoolsForTable}
+              onRowClick={handleSelectSchool}
+            />
             <div className="mt-6 flex justify-center">
               <CustomPagination
                 currentPage={tablePage}

--- a/client/src/modules/Schools/components/SchoolTables.tsx
+++ b/client/src/modules/Schools/components/SchoolTables.tsx
@@ -23,6 +23,7 @@ import { SortableHeader } from './SortableHeader';
 
 type SchoolsTableProps = {
   data: SchoolProps[];
+  onRowClick?: (school: SchoolProps) => void;
 };
 
 const dependencyStyles: { [key: string]: string } = {
@@ -34,7 +35,7 @@ const locationStyles: { [key: string]: string } = {
   Rural: 'bg-yellow-100 text-yellow-800',
 };
 
-export const SchoolsTable = ({ data }: SchoolsTableProps) => {
+export const SchoolsTable = ({ data, onRowClick  }: SchoolsTableProps) => {
   const navigate = useNavigate();
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -133,8 +134,9 @@ export const SchoolsTable = ({ data }: SchoolsTableProps) => {
   });
 
   const handleRowClick = (rowData: SchoolProps) => {
-    const schoolId = rowData.id; 
-    navigate(`/escolas/${schoolId}`);
+    if (onRowClick) {
+      onRowClick(rowData);
+    }
   };
 
   return (

--- a/client/src/modules/Simulator/SimulatorDetails/SimulatorDetailsPage.tsx
+++ b/client/src/modules/Simulator/SimulatorDetails/SimulatorDetailsPage.tsx
@@ -1,0 +1,98 @@
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getSchoolDetailsUseCase } from '@/shared/services/Schools/logic/getSchoolDetailsUseCase';
+import { useState, useEffect } from 'react';
+import { SimulatorControlPanel } from './components/SimulatorControlPanel';
+import Spinner from '@/ui/components/common/Spinner';
+import { SimulateRiskScoreUseCase } from '../logic/SimulateRiskScoreUseCase';
+import { SchoolHeader } from '@/modules/Schools/SchoolDetails/components/SchoolHeader';
+import { SimulatorResultsPanel } from './components/SimulatorResultsPanel';
+
+const SimulatorDetailsPage = () => {
+  const { id: schoolId } = useParams<{ id: string }>();
+  const [selectedInterventions, setSelectedInterventions] = useState<string[]>(
+    [],
+  );
+  const [simulationResult, setSimulationResult] = useState<{
+    currentScore: number;
+    simulatedScore: number;
+  } | null>(null);
+
+  const { data: school, isLoading: isLoadingSchool } = useQuery({
+    queryKey: ['school-details-for-simulator', schoolId],
+    queryFn: () => getSchoolDetailsUseCase.execute(schoolId!),
+    enabled: !!schoolId,
+  });
+
+  useEffect(() => {
+    if (school) {
+      setSimulationResult({
+        currentScore: school.scoreDeRisco,
+        simulatedScore: school.scoreDeRisco,
+      });
+    }
+  }, [school]);
+
+  const { mutate: runSimulation, isPending: isSimulating } = useMutation({
+    mutationFn: SimulateRiskScoreUseCase.execute,
+    onSuccess: (data) => {
+      setSimulationResult({
+        currentScore: data.currentScore,
+        simulatedScore: data.simulatedScore,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (schoolId) {
+      runSimulation({ schoolId, interventions: selectedInterventions });
+    }
+  }, [selectedInterventions, schoolId, runSimulation]);
+
+  const handleInterventionChange = (
+    interventionKey: string,
+    isSelected: boolean,
+  ) => {
+    setSelectedInterventions((prev) =>
+      isSelected
+        ? [...prev, interventionKey]
+        : prev.filter((item) => item !== interventionKey),
+    );
+  };
+
+  if (isLoadingSchool) {
+    return (
+      <div className="flex h-full w-full items-center justify-center py-20">
+        <Spinner />
+      </div>
+    );
+  }
+  if (!school) {
+    return (
+      <div className="text-center font-semibold text-lg text-brand-text-secondary py-20">
+        Escola não encontrada.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SchoolHeader school={school} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+        {/* 2. A página agora renderiza nossos dois painéis superpoderosos */}
+        <SimulatorControlPanel
+          schoolInfra={school.infraestrutura}
+          selectedInterventions={selectedInterventions}
+          onInterventionChange={handleInterventionChange}
+        />
+        <SimulatorResultsPanel
+          isSimulating={isSimulating}
+          simulationResult={simulationResult}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SimulatorDetailsPage;

--- a/client/src/modules/Simulator/SimulatorDetails/components/ScoreGauge.tsx
+++ b/client/src/modules/Simulator/SimulatorDetails/components/ScoreGauge.tsx
@@ -1,0 +1,65 @@
+import {
+  RadialBar,
+  RadialBarChart,
+  Legend,
+  ResponsiveContainer,
+  PolarAngleAxis,
+} from 'recharts';
+
+type ScoreGaugeProps = {
+  initialScore: number;
+  simulatedScore: number;
+};
+
+export const ScoreGauge = ({
+  initialScore,
+  simulatedScore,
+}: ScoreGaugeProps) => {
+  const data = [
+    { name: 'Score Atual', value: initialScore * 100, fill: '#E5E7EB' }, 
+    { name: 'Score Simulado', value: simulatedScore * 100, fill: '#D46419' }, 
+  ];
+
+  const reduction = initialScore - simulatedScore;
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center h-full">
+      <div className="w-full h-48">
+        <ResponsiveContainer>
+          <RadialBarChart
+            innerRadius="70%"
+            outerRadius="100%"
+            data={data}
+            startAngle={180}
+            endAngle={0}
+            barSize={20}
+          >
+            <PolarAngleAxis
+              type="number"
+              domain={[0, 100]}
+              angleAxisId={0}
+              tick={false}
+            />
+            <RadialBar background dataKey="value" angleAxisId={0} />
+            <Legend
+              iconSize={10}
+              layout="vertical"
+              verticalAlign="bottom"
+              align="center"
+              wrapperStyle={{ fontSize: '12px' }}
+            />
+          </RadialBarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="text-4xl font-bold text-brand-orange-dark -mt-10">
+        {(simulatedScore * 100).toFixed(1)}%
+      </p>
+      <p className="text-sm text-brand-text-secondary">Score Simulado</p>
+      {reduction > 0 && (
+        <p className="mt-4 font-semibold text-green-600 bg-green-100 px-3 py-1 rounded-full">
+          Redução de {(reduction * 100).toFixed(1)}%
+        </p>
+      )}
+    </div>
+  );
+};

--- a/client/src/modules/Simulator/SimulatorDetails/components/SimulatorControlPanel.tsx
+++ b/client/src/modules/Simulator/SimulatorDetails/components/SimulatorControlPanel.tsx
@@ -1,0 +1,86 @@
+import { School } from '@/domain/entities/School/SchoolProps';
+import { Label } from '@/ui/components/common/label';
+import { Switch } from '@/ui/components/common/switch';
+import {
+  Atom,
+  BookOpen,
+  CheckCircle2,
+  Computer,
+  LandPlot,
+  Recycle,
+  Wifi,
+} from 'lucide-react';
+
+const infraMap = {
+  possui_biblioteca: { label: 'Biblioteca/Leitura', Icon: BookOpen },
+  possui_internet_para_alunos: { label: 'Internet para Alunos', Icon: Wifi },
+  possui_laboratorio_ciencias: {
+    label: 'Laboratório de Ciências',
+    Icon: Atom,
+  },
+  possui_laboratorio_informatica: {
+    label: 'Laboratório de Informática',
+    Icon: Computer,
+  },
+  possui_quadra_esportes: { label: 'Quadra de Esportes', Icon: LandPlot },
+  possui_saneamento_basico: { label: 'Saneamento Básico', Icon: Recycle },
+};
+
+type SimulatorControlPanelProps = {
+  schoolInfra: School['infraestrutura'];
+  selectedInterventions: string[];
+  onInterventionChange: (interventionKey: string, isSelected: boolean) => void;
+};
+
+export const SimulatorControlPanel = ({
+  schoolInfra,
+  selectedInterventions,
+  onInterventionChange,
+}: SimulatorControlPanelProps) => {
+  return (
+    <div className="bg-white p-6 rounded-2xl shadow-sm border h-full">
+      <h2 className="text-xl font-bold text-brand-text-primary mb-4 border-b pb-2">
+        Painel de Intervenções
+      </h2>
+      <div className="space-y-4">
+        {Object.keys(infraMap).map((key) => {
+          const hasFeature = schoolInfra[key] === true;
+          const config = infraMap[key as keyof typeof infraMap];
+
+          return (
+            <div
+              key={key}
+              className={`flex items-center justify-between p-3 rounded-lg ${
+                hasFeature
+                  ? 'bg-gray-100 opacity-60 cursor-not-allowed'
+                  : 'hover:bg-gray-50'
+              }`}
+            >
+              <Label
+                htmlFor={key}
+                className="font-semibold text-brand-text-primary flex items-center gap-3"
+              >
+                <config.Icon className="h-5 w-5 text-brand-orange-dark" />
+                {config.label}
+              </Label>
+              {hasFeature ? (
+                <div className="flex items-center gap-2 text-sm text-green-600 font-medium">
+                  <CheckCircle2 className="h-4 w-4" />
+                  <span>Já Possui</span>
+                </div>
+              ) : (
+                <Switch
+                  id={key}
+                  checked={selectedInterventions.includes(key)}
+                  onCheckedChange={(isChecked) =>
+                    onInterventionChange(key, isChecked)
+                  }
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/client/src/modules/Simulator/SimulatorDetails/components/SimulatorResultsPanel.tsx
+++ b/client/src/modules/Simulator/SimulatorDetails/components/SimulatorResultsPanel.tsx
@@ -1,0 +1,91 @@
+import RiskIndicator from '@/ui/components/common/RiskIndicator';
+import Spinner from '@/ui/components/common/Spinner';
+import { TrendingDown } from 'lucide-react';
+
+type SimulatorResultsPanelProps = {
+  isSimulating: boolean;
+  simulationResult: {
+    currentScore: number;
+    simulatedScore: number;
+  } | null;
+};
+
+const ResultCard = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex-1 p-4 bg-gray-50 rounded-lg text-center">
+    <p className="text-sm font-semibold text-brand-text-secondary">{title}</p>
+    {children}
+  </div>
+);
+
+export const SimulatorResultsPanel = ({
+  isSimulating,
+  simulationResult,
+}: SimulatorResultsPanelProps) => {
+  if (isSimulating || !simulationResult) {
+    return (
+      <div className="bg-white p-6 rounded-2xl shadow-sm border sticky top-6 h-64 flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const { currentScore, simulatedScore } = simulationResult;
+  const reduction = currentScore - simulatedScore;
+  const reductionPercentage =
+    reduction > 0 ? (reduction / currentScore) * 100 : 0;
+
+  return (
+    <div className="bg-white p-6 rounded-2xl shadow-sm border sticky top-6">
+      <h2 className="text-xl font-bold text-brand-text-primary mb-4 text-center">
+        Impacto no Score de Risco
+      </h2>
+      <div className="flex flex-col sm:flex-row gap-4">
+        {/* Card ANTES */}
+        <ResultCard title="Score Atual">
+          <p className="text-3xl font-bold text-brand-text-secondary">
+            {(currentScore * 100).toFixed(0)}%
+          </p>
+          <div className="mt-1 flex justify-center">
+            <RiskIndicator score={currentScore} />
+          </div>
+        </ResultCard>
+
+        {/* Card DEPOIS */}
+        <ResultCard title="Score Simulado">
+          <p className="text-3xl font-bold text-brand-orange-dark">
+            {(simulatedScore * 100).toFixed(0)}%
+          </p>
+          <div className="mt-1 flex justify-center">
+            <RiskIndicator score={simulatedScore} />
+          </div>
+        </ResultCard>
+      </div>
+
+      {/* Card de REDUÇÃO */}
+      {reduction > 0.001 && (
+        <div className="mt-4 p-4 bg-green-50 border-l-4 border-green-500 rounded-r-lg">
+          <div className="flex items-center gap-2">
+            <TrendingDown className="h-5 w-5 text-green-600" />
+            <p className="text-lg font-bold text-green-700">
+              Redução de {reductionPercentage.toFixed(1)}%
+            </p>
+          </div>
+          <p className="text-sm text-green-600 pl-7">
+            O risco da escola diminuiu significativamente.
+          </p>
+        </div>
+      )}
+      {reduction === 0 && (
+        <div className="mt-4 p-4 text-center text-brand-text-secondary">
+          <p>Selecione uma intervenção para ver o impacto.</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/src/modules/Simulator/SimulatorPage.tsx
+++ b/client/src/modules/Simulator/SimulatorPage.tsx
@@ -1,0 +1,50 @@
+import { Microscope } from 'lucide-react';
+import SimulatorSchoolSelection from './SimulatorSchoolSelection/SimulatorSchoolSelection';
+import { SimulatorStrategicPlanner } from './SimulatorStrategicPlanner/components/SimulatorStrategicPlanner';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/ui/components/common/tabs';
+
+const SimulatorPage = () => {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <div className="p-3 bg-brand-orange-light/20 rounded-lg">
+          <Microscope className="h-8 w-8 text-brand-orange-dark" />
+        </div>
+        <div>
+          <h1 className="text-3xl font-bold text-brand-text-primary">
+            Simulador de{' '}
+            <span className="text-brand-orange-dark">Impacto </span>
+          </h1>
+          <p className="text-brand-text-secondary mt-1">
+            Analise cenários de investimento e planeje intervenções
+            estratégicas.
+          </p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="school-analysis" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="school-analysis">Análise por Escola</TabsTrigger>
+          <TabsTrigger value="strategic-planning">
+            Planejamento Estratégico
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="school-analysis" className="mt-6">
+          <SimulatorSchoolSelection />
+        </TabsContent>
+
+        <TabsContent value="strategic-planning" className="mt-6">
+          <SimulatorStrategicPlanner />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default SimulatorPage;

--- a/client/src/modules/Simulator/SimulatorSchoolSelection/SimulatorSchoolSelection.tsx
+++ b/client/src/modules/Simulator/SimulatorSchoolSelection/SimulatorSchoolSelection.tsx
@@ -1,21 +1,21 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Spinner from '@/ui/components/common/Spinner';
-import DashboardFilters from '../Dashboard/components/custom/DashboardFilters';
-import { Input } from '@/ui/components/common/input';
-import { School2, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { useDebounce } from '@/ui/hooks/useDebounce';
 import { usePagination } from '@/ui/hooks/usePagination';
 import { CustomPagination } from '@/ui/components/common/CustomPagination';
-import { SchoolsTable } from './components/SchoolTables';
-import { listSchoolsUseCase } from '@/shared/services/Schools/logic/listPaginatedSchoolsUseCase';
 import { useFilters } from '@/ui/context/FiltersContext';
 import { School } from '@/domain/entities/School/SchoolProps';
-import { useNavigate } from 'react-router-dom';
+import { listSchoolsUseCase } from '@/shared/services/Schools/logic/listPaginatedSchoolsUseCase';
+import DashboardFilters from '../../Dashboard/components/custom/DashboardFilters';
+import { Input } from '@/ui/components/common/input';
+import { SchoolsTable } from '../../Schools/components/SchoolTables';
 
 const PAGE_SIZE = 25;
 
-const SchoolsPage = () => {
+const SimulatorSchoolSelection = () => {
   const [page, setPage] = useState(1);
   const { filters } = useFilters();
   const navigate = useNavigate();
@@ -28,7 +28,12 @@ const SchoolsPage = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['schools-list', page, debouncedSearchTerm, filters],
+    queryKey: [
+      'schools-list-for-simulator',
+      page,
+      debouncedSearchTerm,
+      filters,
+    ],
     queryFn: () =>
       listSchoolsUseCase.execute({
         page,
@@ -54,39 +59,11 @@ const SchoolsPage = () => {
   }, [debouncedSearchTerm, filters]);
 
   const handleSelectSchool = (school: School) => {
-    navigate(`/escolas/${school.id}`);
+    navigate(`/simulador/${school.id || school.inep}`);
   };
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-brand-orange-light/20 rounded-lg">
-            <School2 className="h-8 w-8 text-brand-orange-dark" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold text-brand-text-primary">
-              Análise de Escolas{' '}
-              <span className="text-brand-orange-dark">da Paraíba </span>
-            </h1>
-            <p className="text-brand-text-secondary mt-1">
-              Explore, filtre e analise os dados de todas as escolas da rede
-              pública.
-            </p>
-          </div>
-        </div>
-        <div className="text-right">
-          <p className="font-semibold text-brand-text-primary">
-            Exibindo {schoolsOnPage.length} de {totalSchools}
-          </p>
-          <p className="text-xs text-brand-text-secondary">
-            {searchTerm || Object.values(filters).some((v) => v)
-              ? 'Escolas Filtradas'
-              : 'Total de Escolas'}
-          </p>
-        </div>
-      </div>
-
       <DashboardFilters />
 
       <div className="bg-white p-6 rounded-2xl shadow-sm border border-gray-200">
@@ -101,15 +78,16 @@ const SchoolsPage = () => {
         </div>
 
         {isLoading && (
-          <div className="flex justify-center items-center h-64">
+          <div className="flex justify-center items-center h-96">
             <Spinner />
           </div>
         )}
         {isError && (
-          <div className="text-center text-red-500">
-            Ocorreu um erro ao buscar os dados das escolas.
+          <div className="text-center text-red-500 py-10">
+            Erro ao carregar os dados.
           </div>
         )}
+
         {!isLoading && !isError && totalSchools > 0 && (
           <>
             <SchoolsTable
@@ -136,4 +114,4 @@ const SchoolsPage = () => {
   );
 };
 
-export default SchoolsPage;
+export default SimulatorSchoolSelection;

--- a/client/src/modules/Simulator/SimulatorStrategicPlanner/components/InterventionCard.tsx
+++ b/client/src/modules/Simulator/SimulatorStrategicPlanner/components/InterventionCard.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/shared/lib/utils';
+import React from 'react';
+
+type InterventionCardProps = {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  isSelected: boolean;
+  onClick: () => void;
+};
+
+export const InterventionCard = ({
+  icon: Icon,
+  title,
+  description,
+  isSelected,
+  onClick,
+}: InterventionCardProps) => {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'flex flex-col items-center justify-center text-center p-6 rounded-2xl border-2 transition-all duration-200',
+        isSelected
+          ? 'border-brand-orange-dark bg-brand-orange-light/10 shadow-lg'
+          : 'bg-white hover:bg-gray-50 hover:shadow-md border-gray-200',
+      )}
+    >
+      <div
+        className={cn(
+          'p-3 rounded-full mb-3',
+          isSelected ? 'bg-brand-orange-dark' : 'bg-brand-orange-light/20',
+        )}
+      >
+        <Icon
+          className={cn(
+            'h-8 w-8',
+            isSelected ? 'text-white' : 'text-brand-orange-dark',
+          )}
+        />
+      </div>
+      <h3 className="font-bold text-lg text-brand-text-primary">{title}</h3>
+      <p className="text-sm text-brand-text-secondary mt-1">{description}</p>
+    </button>
+  );
+};

--- a/client/src/modules/Simulator/SimulatorStrategicPlanner/components/SimulatorStrategicPlanner.tsx
+++ b/client/src/modules/Simulator/SimulatorStrategicPlanner/components/SimulatorStrategicPlanner.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { InterventionCard } from './InterventionCard';
+import { BookOpen, Wifi, Recycle } from 'lucide-react'; 
+
+const interventions = [
+  {
+    key: 'possui_biblioteca',
+    title: 'Construir Biblioteca',
+    description:
+      'Encontre escolas onde uma nova biblioteca geraria o maior impacto.',
+    Icon: BookOpen,
+  },
+  {
+    key: 'possui_internet_para_alunos',
+    title: 'Internet para Alunos',
+    description:
+      'Identifique escolas que mais se beneficiariam de acesso à internet para estudantes.',
+    Icon: Wifi,
+  },
+  {
+    key: 'possui_saneamento_basico',
+    title: 'Saneamento Básico',
+    description:
+      'Veja o ranking de impacto para a implementação de saneamento básico.',
+    Icon: Recycle,
+  },
+];
+
+export const SimulatorStrategicPlanner = () => {
+  const [selectedIntervention, setSelectedIntervention] = useState<
+    string | null
+  >(null);
+
+  return (
+    <div className="space-y-8">
+      {/* Seção 1: Seleção da Intervenção */}
+      <div className="bg-white p-6 rounded-2xl shadow-sm border">
+        <h2 className="text-xl font-bold text-brand-text-primary">
+          1. Selecione uma Intervenção Estratégica
+        </h2>
+        <p className="text-brand-text-secondary mt-1 mb-4">
+          Escolha um tipo de investimento para ver o ranking de escolas com
+          maior potencial de impacto.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {interventions.map((item) => (
+            <InterventionCard
+              key={item.key}
+              title={item.title}
+              description={item.description}
+              icon={item.Icon}
+              isSelected={selectedIntervention === item.key}
+              onClick={() => setSelectedIntervention(item.key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Seção 2: Resultados (Aparece quando uma intervenção é selecionada) */}
+      {selectedIntervention && (
+        <div className="bg-white p-6 rounded-2xl shadow-sm border animate-in fade-in duration-500">
+          <h2 className="text-xl font-bold text-brand-text-primary mb-4">
+            2. Ranking de Impacto
+          </h2>
+          <div className="text-center py-16 border-2 border-dashed rounded-lg">
+            <p className="text-brand-text-secondary">
+              (Aqui entrarão o mapa e a tabela com o ranking das escolas)
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/src/modules/Simulator/logic/SimulateRiskScoreUseCase.ts
+++ b/client/src/modules/Simulator/logic/SimulateRiskScoreUseCase.ts
@@ -1,0 +1,22 @@
+import { schoolRepository } from '@/shared/services/Schools/repositories/schoolRepository';
+
+type SimulateRiskScoreParams = {
+  schoolId: string;
+  interventions: string[];
+};
+
+type SimulateRiskScoreResponse = {
+  currentScore: number;
+  simulatedScore: number;
+  scoreReduction: number;
+};
+
+const execute = (
+  params: SimulateRiskScoreParams,
+): Promise<SimulateRiskScoreResponse> => {
+  return schoolRepository.simulateRiskScore(params);
+};
+
+export const SimulateRiskScoreUseCase = {
+  execute,
+};

--- a/client/src/shared/services/Schools/repositories/schoolRepository.ts
+++ b/client/src/shared/services/Schools/repositories/schoolRepository.ts
@@ -31,6 +31,17 @@ type ListOrSearchParams = {
   tipoLocalizacao?: string;
 };
 
+type SimulateRiskScoreParams = {
+  schoolId: string;
+  interventions: string[];
+};
+
+type SimulateRiskScoreResponse = {
+  currentScore: number;
+  simulatedScore: number;
+  scoreReduction: number;
+};
+
 export interface ISchoolRepository {
   search(
     searchTerm: string,
@@ -40,6 +51,7 @@ export interface ISchoolRepository {
   listOrSearch(params: ListOrSearchParams): Promise<PaginatedResponse<School>>;
   listForMap(filters: FiltersOptions): Promise<SchoolForMap[]>;
   findById(id: string): Promise<School | null>;
+  simulateRiskScore(params: SimulateRiskScoreParams): Promise<SimulateRiskScoreResponse>;
 }
 
 const listForMap = async (filters: FiltersOptions): Promise<SchoolForMap[]> => {
@@ -150,9 +162,27 @@ const findById = async (id: string): Promise<School | null> => {
   }
 };
 
+const simulateRiskScore = async (
+  params: SimulateRiskScoreParams,
+): Promise<SimulateRiskScoreResponse> => {
+  console.log('Simulando score para a escola:', params.schoolId);
+  console.log('Com as seguintes intervenções:', params.interventions);
+
+  const mockResponse: SimulateRiskScoreResponse = {
+    currentScore: 0.85, 
+    simulatedScore: 0.85 - params.interventions.length * 0.07,
+    scoreReduction: params.interventions.length * 0.07,
+  };
+
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  return mockResponse;
+};
+
 export const schoolRepository: ISchoolRepository = {
   search,
   listForMap,
   listOrSearch,
   findById,
+  simulateRiskScore
 };

--- a/client/src/ui/components/common/switch.tsx
+++ b/client/src/ui/components/common/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+import { cn } from "@/shared/lib/utils"
+
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-orange-dark data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/client/src/ui/components/common/tabs.tsx
+++ b/client/src/ui/components/common/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { cn } from "@/shared/lib/utils"
+
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-brand-orange-dark data-[state=active]:text-white data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/client/src/ui/components/layout/DesktopNavActions.tsx
+++ b/client/src/ui/components/layout/DesktopNavActions.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Bell, Settings, HelpCircle } from 'lucide-react';
-import NotificationsDropdown from './NotificationsDropdown';
+import { Settings, HelpCircle } from 'lucide-react';
 
 interface DesktopNavActionsProps {
   isNotificationsOpen: boolean;
@@ -11,25 +10,11 @@ interface DesktopNavActionsProps {
 }
 
 export const DesktopNavActions = ({
-  isNotificationsOpen,
-  onNotificationsClick,
   onSettingsClick,
   onAboutClick,
-  notificationsRef,
 }: DesktopNavActionsProps) => {
   return (
     <div className="hidden sm:flex items-center gap-2 md:gap-6">
-      <div className="relative" ref={notificationsRef}>
-        <button
-          onClick={onNotificationsClick}
-          className="relative text-brand-text-secondary hover:text-brand-orange-light transition-colors"
-        >
-          <Bell className="h-6 w-6" />
-          <span className="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500 ring-2 ring-white" />
-        </button>
-        <NotificationsDropdown isOpen={isNotificationsOpen} />
-      </div>
-
       <button
         onClick={onSettingsClick}
         className="text-brand-text-secondary hover:text-brand-orange-light transition-colors"

--- a/client/src/ui/components/layout/Menu.tsx
+++ b/client/src/ui/components/layout/Menu.tsx
@@ -4,10 +4,8 @@ import {
   School,
   Map,
   Microscope,
-  Settings,
   AlertCircle,
   FileText,
-  Network,
   FileSearchIcon,
 } from 'lucide-react';
 import React from 'react';
@@ -51,7 +49,7 @@ const menuItems: MenuItem[] = [
     path: '/simulador',
     Icon: Microscope,
     group: 'Ferramentas',
-    disabled: true,
+    disabled: false,
   },
   {
     id: 5,
@@ -59,7 +57,7 @@ const menuItems: MenuItem[] = [
     path: '/necessidades',
     Icon: AlertCircle,
     group: 'Ferramentas',
-    disabled: true,
+    disabled: false,
   },
   {
     id: 6,
@@ -67,22 +65,6 @@ const menuItems: MenuItem[] = [
     path: '/relatorios',
     Icon: FileText,
     group: 'Ferramentas',
-    disabled: true,
-  },
-  {
-    id: 7,
-    title: 'Ecossistema',
-    path: '/ecossistema',
-    Icon: Network,
-    group: 'Avançado',
-    disabled: true,
-  },
-  {
-    id: 8,
-    title: 'Configurações',
-    path: '/configuracoes',
-    Icon: Settings,
-    group: 'Sistema',
     disabled: true,
   },
   {

--- a/etl/.dockerignore
+++ b/etl/.dockerignore
@@ -14,3 +14,6 @@ dados/
 .vscode/
 .idea/
 .DS_Store
+
+notebooks/
+mlruns/

--- a/model-training-pipeline/.dockerignore
+++ b/model-training-pipeline/.dockerignore
@@ -21,3 +21,6 @@ dados/
 .vscode/
 .idea/
 .DS_Store
+
+notebooks/
+mlruns/


### PR DESCRIPTION
## O que este PR faz?
Implementa a parte visual e prototipada do simulador de impacto.
A primeira parte é uma listagem de seleção individual de escolas
A segunda é um planejamento estrategico, onde você seleciona uma intervenção
e recebe uma lista de escolas que mais se beneficiariam daquele investimento.

**TUDO** é mockado e prototipo, nao temos nada de api e nada definitivo, apenas para fins 
de visualização.

## Link da Task no Linear:

```Text
Exemplo:

Fixes ALP-21 – [Ver issue](https://linear.app/alpargatas-insights/issue/ALP-21/...)
Fixes ALP-24 – [Ver issue](https://linear.app/alpargatas-insights/issue/ALP-24/...)
```

## Screenshots ou GIFs (se aplicável)
https://github.com/user-attachments/assets/22593045-f4f8-4639-a8c5-77d1d5803b89

## Checklist de Qualidade

- [ ] Meu código segue as boas práticas e a arquitetura que definimos para o projeto.
- [ ] Eu testei minhas alterações localmente e elas funcionam como esperado.

### Checklist de Pré-Submissão

_Antes de abrir esta PR, por favor, confirme que você completou os seguintes passos:_

- [ ] Eu testei minhas alterações localmente.
- [ ] Eu li e preenchi as seções acima.
